### PR TITLE
Prevent crashing if no parameters defined in the schema

### DIFF
--- a/src/route.ts
+++ b/src/route.ts
@@ -95,7 +95,7 @@ export class OpenAPIRoute implements OpenAPIRouteSchema {
   }
 
   validateRequest(request: Request): any {
-    const params = this.getSchema().parameters
+    const params = this.getSchema().parameters || {}
     const queryParams = extractQueryParameters(request)
 
     const validatedObj = {}


### PR DESCRIPTION
In the `OpenAPISchema` interface the `parameters` attribute is optional / can be undefined. However there's an `Object.entries(params)` that fails in that case.

With this PR, `params` is always defined and `Object.entries` always succeeds.

Another option would've been to add an if statement. But this was the smallest change to make it work.