### PR TITLE
Update TypeScript compilation target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     // "module": "commonjs",                  /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "lib": ["esnext"],
     /* Specify library files to be included in the compilation. */ // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
I'm not 100% sure that `ES2020` is the best target, but I think the target should be updated because currently the generated JS is too verbose. It even assumes that async/await are not supported by the runtime.

Specially since this library is meant to be used only in cloudflare workers:
- most modern JS features should be supported.
- the size of the generated JS matters.

Here's a list of files with the before/after size:

```
dist/cjs/exceptions.js  1.8K -> 653B
dist/cjs/index.js       816B -> 816B
dist/cjs/openapi.js     5.9K -> 4.1K
dist/cjs/parameters.js   17K ->  13K
dist/cjs/route.js       8.7K -> 3.6K
dist/cjs/types.js        77B ->  77B
dist/cjs/ui.js          1.7K -> 1.6K
dist/esm/exceptions.js  1.6K -> 364B
dist/esm/index.js       137B -> 137B
dist/esm/openapi.js     5.7K -> 3.9K
dist/esm/parameters.js   16K ->  12K
dist/esm/route.js       8.5K -> 3.4K
dist/esm/types.js        11B ->  11B
dist/esm/ui.js          1.6K -> 1.5K
```