### PR TITLE
Parameters should always be an array

### DIFF
--- a/src/route.ts
+++ b/src/route.ts
@@ -48,7 +48,7 @@ export class OpenAPIRoute implements OpenAPIRouteSchema {
     // Deep copy
     return {
       ...schema,
-      parameters: schema.parameters ? getFormatedParameters(schema.parameters) : {},
+      parameters: schema.parameters ? getFormatedParameters(schema.parameters) : [],
       responses: responses,
       ...(requestBody ? { requestBody: requestBody } : {}),
     }


### PR DESCRIPTION
When a route doesn't have `parameters` defined, the OpenAPI spec is returning an empty object. I think it should always return an array instead.