### PR TITLE
Improve Enumeration constructor types

### DIFF
--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -361,14 +361,16 @@ export class Bool extends Str {
 export class Enumeration extends Str {
   public isEnum = true
   public declare params: EnumerationParameterType
-  public values: Record<string, unknown>
+  public values: Record<string, any>
   public keys: any
 
   constructor(params: EnumerationParameterType) {
     super(params)
 
-    this.keys = Object.keys(params.values)
-    this.values = params.values
+    let {values} = params
+    if (Array.isArray(values)) values = Object.fromEntries(values.map((x) => [x, x]))
+    this.keys = Object.keys(values)
+    this.values = values
   }
 
   validate(value: any): any {

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -361,7 +361,7 @@ export class Bool extends Str {
 export class Enumeration extends Str {
   public isEnum = true
   public declare params: EnumerationParameterType
-  public values: Record<string, any>
+  public values: Record<string, unknown>
   public keys: any
 
   constructor(params: EnumerationParameterType) {


### PR DESCRIPTION
I spent some time trying to understand why something as simple as this wasn't working:

```ts
new Enumeration({
  description: "",
  values: ["enabled", "disabled", "custom"],
  required: false,
}),
```

Then, digging into the code and checking the docs I saw that `values` needs to be `Record<string, any>`. But then, why TypeScript wasn't complaining?

It turns out that an array of strings satisfies `Record<string, any>`. Yeah: https://www.typescriptlang.org/play?#code/MYewdgzgLgBADgQwE4ILYQFwwEoFNRIAmAPNEgJZgDmANDAmAJ4B8MAvDANoDkC3AugChBoSCAA2uAHTiQVABSIU6AJRA

So, It'd be better to use `Record<string, unknown>` instead, which gives a compiler error if you try to pass an array of strings.