### PR TITLE
Add OpenAI plugin support

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -156,7 +156,7 @@ export function OpenAPIRouter(options?: RouterOptions): OpenAPIRouterSchema {
             api: {
               type: APIType.OPENAPI,
               has_user_authentication: false,
-              url: `https://${request.headers.get('host')}/openapi.json`,
+              url: `https://${request.headers.get('host')}${options?.openapi_url || '/openapi.json'}`,
             },
             auth: {
               type: AuthType.NONE,

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -147,6 +147,17 @@ export function OpenAPIRouter(options?: RouterOptions): OpenAPIRouterSchema {
         })
       })
     }
+
+    if (options?.aiPlugin !== null) {
+      router.get('/.well-known/ai-plugin.json', () => {
+        return new Response(JSON.stringify(options?.aiPlugin), {
+          headers: {
+            'content-type': 'application/json;charset=UTF-8',
+          },
+          status: 200,
+        })
+      })
+    }
   }
 
   return routerProxy

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -152,17 +152,15 @@ export function OpenAPIRouter(options?: RouterOptions): OpenAPIRouterSchema {
       router.get('/.well-known/ai-plugin.json', (request: IRequest) => {
         return new Response(
           JSON.stringify({
-            ...options?.aiPlugin,
             api: {
               type: APIType.OPENAPI,
               has_user_authentication: false,
               url: `https://${request.headers.get('host')}/openapi.json`,
-              ...options?.aiPlugin?.api,
             },
             auth: {
               type: AuthType.NONE,
-              ...options?.aiPlugin?.auth,
             },
+            ...options?.aiPlugin,
           }),
           {
             headers: {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,7 +1,7 @@
 import { getReDocUI, getSwaggerUI } from './ui'
 import { Router, IRequest } from 'itty-router'
 import { getFormatedParameters, Query } from './parameters'
-import { OpenAPIRouterSchema, OpenAPISchema, RouterOptions, APIType, AuthType } from './types'
+import { OpenAPIRouterSchema, OpenAPISchema, RouterOptions, APIType, AuthType, SchemaVersion } from './types'
 
 export function OpenAPIRouter(options?: RouterOptions): OpenAPIRouterSchema {
   const OpenAPIPaths: Record<string, Record<string, any>> = {}
@@ -152,6 +152,7 @@ export function OpenAPIRouter(options?: RouterOptions): OpenAPIRouterSchema {
       router.get('/.well-known/ai-plugin.json', (request: IRequest) => {
         return new Response(
           JSON.stringify({
+            schema_version: SchemaVersion.V1,
             api: {
               type: APIType.OPENAPI,
               has_user_authentication: false,

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,7 +1,7 @@
 import { getReDocUI, getSwaggerUI } from './ui'
-import { Router } from 'itty-router'
+import { Router, IRequest } from 'itty-router'
 import { getFormatedParameters, Query } from './parameters'
-import { OpenAPIRouterSchema, OpenAPISchema, RouterOptions } from './types'
+import { OpenAPIRouterSchema, OpenAPISchema, RouterOptions, APIType, AuthType } from './types'
 
 export function OpenAPIRouter(options?: RouterOptions): OpenAPIRouterSchema {
   const OpenAPIPaths: Record<string, Record<string, any>> = {}
@@ -149,13 +149,28 @@ export function OpenAPIRouter(options?: RouterOptions): OpenAPIRouterSchema {
     }
 
     if (options?.aiPlugin && options?.openapi_url !== null) {
-      router.get('/.well-known/ai-plugin.json', () => {
-        return new Response(JSON.stringify(options?.aiPlugin), {
-          headers: {
-            'content-type': 'application/json;charset=UTF-8',
-          },
-          status: 200,
-        })
+      router.get('/.well-known/ai-plugin.json', (request: IRequest) => {
+        return new Response(
+          JSON.stringify({
+            ...options?.aiPlugin,
+            api: {
+              type: APIType.OPENAPI,
+              has_user_authentication: false,
+              url: `https://${request.headers.get('host')}/openapi.json`,
+              ...options?.aiPlugin?.api,
+            },
+            auth: {
+              type: AuthType.NONE,
+              ...options?.aiPlugin?.auth,
+            },
+          }),
+          {
+            headers: {
+              'content-type': 'application/json;charset=UTF-8',
+            },
+            status: 200,
+          }
+        )
       })
     }
   }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -148,7 +148,7 @@ export function OpenAPIRouter(options?: RouterOptions): OpenAPIRouterSchema {
       })
     }
 
-    if (options?.aiPlugin !== null) {
+    if (options?.aiPlugin && options?.openapi_url !== null) {
       router.get('/.well-known/ai-plugin.json', () => {
         return new Response(JSON.stringify(options?.aiPlugin), {
           headers: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface RouterOptions {
   docs_url?: string
   redoc_url?: string
   openapi_url?: string
+  aiPlugin?: AIPlugin
 }
 
 export interface OpenAPISchema {
@@ -94,4 +95,53 @@ export interface ResponseSchema {
 export interface RouteValidated {
   data: Record<string, any>
   errors: Record<string, any>
+}
+
+export enum SchemaVersion {
+  V1 = 'v1',
+}
+
+export enum AuthType {
+  NONE = 'none',
+  OAUTH = 'oauth',
+  SERVICE_HTTP = 'service_http',
+  USER_HTTP = 'user_http',
+}
+
+export enum APIType {
+  OPENAPI = 'openapi',
+}
+
+export interface AIPlugin {
+  schema_version: SchemaVersion
+  name_for_model: string
+  name_for_human: string
+  description_for_model: string
+  description_for_human: string
+  auth: Auth
+  api: API
+  logo_url: string
+  contact_email: string
+  legal_info_url: string
+}
+
+export interface API {
+  type: APIType
+  url: string
+  has_user_authentication: boolean
+}
+
+export interface Auth {
+  type: AuthType
+  authorization_type?: string
+  authorization_url?: string
+  client_url?: string
+  scope?: string
+  authorization_content_type?: string
+  verification_tokens?: VerificationTokens
+  instructions?: string
+}
+
+export interface VerificationTokens {
+  openai: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,8 +118,8 @@ export interface AIPlugin {
   name_for_human: string
   description_for_model: string
   description_for_human: string
-  auth: Auth
-  api: API
+  auth?: Auth
+  api?: API
   logo_url: string
   contact_email: string
   legal_info_url: string


### PR DESCRIPTION
This makes it much easier to spin up a plugin for ChatGPT with Cloudflare Workers by automating the serving of `/.well-known/ai-plugin.json` given a simple configuration when creating the router. The plugin spec already relies on OpenAPI specs, making this a pretty great match.

There are few things that could also be simple to automate, but below is the most bare-bones support.

Here is a simple example:
```typescript
import {
  Query,
  Int,
  AuthType,
  APIType,
  SchemaVersion,
  OpenAPIRoute,
  OpenAPIRouter,
} from "@cloudflare/itty-router-openapi";

const router = OpenAPIRouter({
  schema: {
    info: {
      title: "Hacker News",
      version: "1.0",
    },
  },
  aiPlugin: {
    schema_version: SchemaVersion.V1,
    name_for_human: "Hacker News",
    name_for_model: "hackernews",
    description_for_human: "Get the top hacker news headlines.",
    description_for_model:
      "Plugin for retrieving the current top stories on Hacker News. Use it whenever a user asks something that might be related to Hacker News or current tech news.",
    contact_email: "person@example.com",
    legal_info_url: "https://example.com/legal",
    logo_url: "https://example.com/icon.png",
    auth: {
      type: AuthType.NONE,
    },
    api: {
      type: APIType.OPENAPI,
      url: "https://url-of-this-instance/openapi.json",
      has_user_authentication: false,
    },
  },
});

const Story = {
  title: String,
  url: String,
  user: String,
  domain: String,
  points: Int,
  time: Int,
  time_ago: String,
  comments_count: Int,
  type: String,
  id: Int,
};

class HackerNewsTopStories extends OpenAPIRoute {
  static schema = {
    summary: "Collects the current top stories.",
    parameters: {
      count: Query(Int, {
        description: "number of stories to return.",
        default: 10,
        required: false,
      }),
    },
    responses: {
      200: {
        schema: {
          headlines: [Story],
        },
      },
    },
  };

  async handle(_request: Request, _env: any, _ctx: any, data: Record<string, any>) {
    const response: (typeof Story)[] = await (
      await fetch("https://api.hnpwa.com/v0/news/1.json")
    ).json();
    return { headlines: response.slice(0, data.count) };
  }
}

router.get("/topStories", HackerNewsTopStories);

export default {
  fetch: router.handle,
};
```