### PR TITLE
fix: schema_version should be optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -113,7 +113,7 @@ export enum APIType {
 }
 
 export interface AIPlugin {
-  schema_version: SchemaVersion
+  schema_version?: SchemaVersion
   name_for_model: string
   name_for_human: string
   description_for_model: string


### PR DESCRIPTION
The schema_version is hardcoded currently and is optional to provide. It doesn't change (yet) so it would be a QoL improvement not to require it.