### PR TITLE
feat: simplify local ChatGPT plugin development

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,7 @@ export interface AIPlugin {
   logo_url: string
   contact_email: string
   legal_info_url: string
+  is_dev?: boolean
 }
 
 export interface API {


### PR DESCRIPTION
When developing ChatGPT plugins locally, there are aspects we can automate to streamline the development process.

This Pull Request introduces an `is_dev` flag to the `aiPlugin` options that serves two purposes:

Modifies the default CORS settings
Alters the URL for the OpenAPI specification to target localhost. This approach assumes the utilization of wrangler dev for local execution.

Please note that this PR addresses the issue specifically concerning the OpenAPI specification and ai-plugin.json files. Further efforts are required to enable routes to adopt these default parameters. I welcome feedback and suggestions on the optimal method to achieve this objective. One alternative idea involves the implementation of a comprehensive "default headers" system that can be automatically applied across all endpoints.