### PR TITLE
Updates itty-router to v4.x and adds isomorphic-fetch to test suite f…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "itty-router": "^4.0.10"
+        "itty-router": "^4.0.11"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^3.18.0",
@@ -3893,9 +3893,9 @@
       }
     },
     "node_modules/itty-router": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.10.tgz",
-      "integrity": "sha512-2B8nfXlHpzRiCEp1uSULRoy1lyzzOmLvLYEcX+Jg2Io9Q7e6F+Lv/qwYv+qzR2z256PmCzaq6yrA+2dnXysy9g=="
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.11.tgz",
+      "integrity": "sha512-I7lm8f76jHUwftzzsFJhYCOvueFFyNNZs9d8HfMP5e6SGGyiOc3sB6/wNGoETTZTVbAufq5M2KKGos+ZkhDW/A=="
     },
     "node_modules/jest": {
       "version": "29.0.0",
@@ -10158,9 +10158,9 @@
       }
     },
     "itty-router": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.10.tgz",
-      "integrity": "sha512-2B8nfXlHpzRiCEp1uSULRoy1lyzzOmLvLYEcX+Jg2Io9Q7e6F+Lv/qwYv+qzR2z256PmCzaq6yrA+2dnXysy9g=="
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.11.tgz",
+      "integrity": "sha512-I7lm8f76jHUwftzzsFJhYCOvueFFyNNZs9d8HfMP5e6SGGyiOc3sB6/wNGoETTZTVbAufq5M2KKGos+ZkhDW/A=="
     },
     "jest": {
       "version": "29.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "itty-router": "^3.0.12"
+        "itty-router": "^4.0.10"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^3.18.0",
@@ -24,6 +24,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",
         "husky": "^7.0.2",
+        "isomorphic-fetch": "^3.0.0",
         "jest": "^29.0.0",
         "jest-openapi": "^0.14.2",
         "pinst": "^2.1.6",
@@ -3806,6 +3807,16 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -3882,9 +3893,9 @@
       }
     },
     "node_modules/itty-router": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
-      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w=="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.10.tgz",
+      "integrity": "sha512-2B8nfXlHpzRiCEp1uSULRoy1lyzzOmLvLYEcX+Jg2Io9Q7e6F+Lv/qwYv+qzR2z256PmCzaq6yrA+2dnXysy9g=="
     },
     "node_modules/jest": {
       "version": "29.0.0",
@@ -5492,6 +5503,48 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5988,9 +6041,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -7054,6 +7107,12 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -10029,6 +10088,16 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -10089,9 +10158,9 @@
       }
     },
     "itty-router": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.12.tgz",
-      "integrity": "sha512-s98XTPhle6GGbaFf0kYrOD3Q8gyhnqvOqkwYijC3AmkceNKqWUp13YHg6dWmqmVv4pP7l7c94XI92I0EXVGO0w=="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.10.tgz",
+      "integrity": "sha512-2B8nfXlHpzRiCEp1uSULRoy1lyzzOmLvLYEcX+Jg2Io9Q7e6F+Lv/qwYv+qzR2z256PmCzaq6yrA+2dnXysy9g=="
     },
     "jest": {
       "version": "29.0.0",
@@ -11368,6 +11437,39 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+          "dev": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "dev": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11753,9 +11855,9 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true
     },
     "pure-rand": {
@@ -12515,6 +12617,12 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
+      "dev": true
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.2",
+    "isomorphic-fetch": "^3.0.0",
     "jest": "^29.0.0",
     "jest-openapi": "^0.14.2",
     "pinst": "^2.1.6",
@@ -87,6 +88,6 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "itty-router": "^3.0.12"
+    "itty-router": "^4.0.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "itty-router": "^4.0.10"
+    "itty-router": "^4.0.11"
   }
 }

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,5 +1,5 @@
 import { getReDocUI, getSwaggerUI } from './ui'
-import { Router, IRequest } from 'itty-router/Router'
+import { Router, IRequest } from 'itty-router/cjs/Router'
 import { getFormatedParameters, Query } from './parameters'
 import { OpenAPIRouterSchema, OpenAPISchema, RouterOptions, APIType, AuthType, SchemaVersion } from './types'
 

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,5 +1,5 @@
 import { getReDocUI, getSwaggerUI } from './ui'
-import { Router, IRequest } from 'itty-router'
+import { Router, IRequest } from 'itty-router/Router'
 import { getFormatedParameters, Query } from './parameters'
 import { OpenAPIRouterSchema, OpenAPISchema, RouterOptions, APIType, AuthType, SchemaVersion } from './types'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { RequestLike, Route, RouteEntry, RouterType } from 'itty-router/Router'
+import { RequestLike, Route, RouteEntry, RouterType } from 'itty-router/cjs/Router'
 import { Parameter } from './parameters'
 
 export interface ClassRoute {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { RequestLike, Route, RouteEntry, RouterType } from 'itty-router'
+import { RequestLike, Route, RouteEntry, RouterType } from 'itty-router/Router'
 import { Parameter } from './parameters'
 
 export interface ClassRoute {

--- a/tests/integration/openapi.test.ts
+++ b/tests/integration/openapi.test.ts
@@ -1,3 +1,4 @@
+import 'isomorphic-fetch'
 import { todoRouter } from '../router'
 import jestOpenAPI from 'jest-openapi'
 

--- a/tests/integration/parameters.test.ts
+++ b/tests/integration/parameters.test.ts
@@ -1,3 +1,4 @@
+import 'isomorphic-fetch'
 import { buildRequest } from '../utils'
 import { ToDoList, todoRouter } from '../router'
 


### PR DESCRIPTION
# Changes
- Updates internal `itty-router` dependency from `3.x` to `4.x`
- Uses direct/tree-shake import `itty-router/cjs/Router` to minimize bundle size
- Adds `isomorphic-fetch` import to test files for `Response` support with contributors

That's it!

Should be a seamless change for your users :)