### PR TITLE
Add zod support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ on:
       - 'README.md'
       - 'LICENSE'
       - '.editorconfig'
-    branches:
-      - main
 
 jobs:
   test:
@@ -34,8 +32,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Install modules
-        run: yarn
+        run: npm install
       - name: Run build
-        run: yarn build
-#      - name: Run tests
-#        run: yarn test
+        run: npm run build
+      - name: Run tests
+        run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "itty-router": "^4.0.13"
+        "@asteasolutions/zod-to-openapi": "^5.3.1",
+        "itty-router": "^4.0.14",
+        "zod": "^3.21.4"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20230518.0",
@@ -19,6 +21,7 @@
         "@rollup/plugin-typescript": "^10.0.1",
         "@types/jest": "^29.0.0",
         "@types/node": "^20.3.1",
+        "@types/service-worker-mock": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
         "@typescript-eslint/parser": "^5.60.0",
         "eslint": "^8.43.0",
@@ -61,6 +64,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asteasolutions/zod-to-openapi": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-5.3.1.tgz",
+      "integrity": "sha512-7/a08FSsjeO6QGEn4EdEU2EkRK6M9Q2+JOlEQNqMzJZGIJ2frV/5op7UNcNcdrPz38RQYjdWMZiia2K80NrzwA==",
+      "dependencies": {
+        "openapi3-ts": "^4.1.2"
+      },
+      "peerDependencies": {
+        "zod": "^3.20.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1900,6 +1914,12 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
+    "node_modules/@types/service-worker-mock": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/service-worker-mock/-/service-worker-mock-2.0.1.tgz",
+      "integrity": "sha512-LqaP0QmgppRF7YEaqx4amoazHNXaX5bIFDAu62LnWIc5ku0HbgqlPKroQstAu8WsdmWIqEfI9VGlP8Skkq+m5A==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {
@@ -4201,9 +4221,9 @@
       }
     },
     "node_modules/itty-router": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.13.tgz",
-      "integrity": "sha512-iiQ9k1nQgaal/MteVft5pwYkvzuZx3idPT9tYpKWl7rKH74tyz5VVSVUCXUO0iBh5HDXjHYsix90UrFKPfThHg=="
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.14.tgz",
+      "integrity": "sha512-s8DfaLkQp+E3kBhjwto3Z91ozulotCLAmlS8AIr230NqwFJssiGIoewo1P+CEkZ3YrzghS9k/RVvmMlvKQxueQ=="
     },
     "node_modules/jest": {
       "version": "29.0.0",
@@ -6060,6 +6080,22 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/openapi3-ts": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.1.2.tgz",
+      "integrity": "sha512-B7gOkwsYMZO7BZXwJzXCuVagym2xhqsrilVvV0dnq2Di4+iLUXKVX9gOK23ZqaAHZOwABXN0QTdW8QnkUTX6DA==",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      }
+    },
+    "node_modules/openapi3-ts/node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -7583,6 +7619,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -7606,6 +7650,14 @@
             "@jridgewell/sourcemap-codec": "^1.4.10"
           }
         }
+      }
+    },
+    "@asteasolutions/zod-to-openapi": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-5.3.1.tgz",
+      "integrity": "sha512-7/a08FSsjeO6QGEn4EdEU2EkRK6M9Q2+JOlEQNqMzJZGIJ2frV/5op7UNcNcdrPz38RQYjdWMZiia2K80NrzwA==",
+      "requires": {
+        "openapi3-ts": "^4.1.2"
       }
     },
     "@babel/code-frame": {
@@ -9062,6 +9114,12 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
+    "@types/service-worker-mock": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/service-worker-mock/-/service-worker-mock-2.0.1.tgz",
+      "integrity": "sha512-LqaP0QmgppRF7YEaqx4amoazHNXaX5bIFDAu62LnWIc5ku0HbgqlPKroQstAu8WsdmWIqEfI9VGlP8Skkq+m5A==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -10732,9 +10790,9 @@
       }
     },
     "itty-router": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.13.tgz",
-      "integrity": "sha512-iiQ9k1nQgaal/MteVft5pwYkvzuZx3idPT9tYpKWl7rKH74tyz5VVSVUCXUO0iBh5HDXjHYsix90UrFKPfThHg=="
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-4.0.14.tgz",
+      "integrity": "sha512-s8DfaLkQp+E3kBhjwto3Z91ozulotCLAmlS8AIr230NqwFJssiGIoewo1P+CEkZ3YrzghS9k/RVvmMlvKQxueQ=="
     },
     "jest": {
       "version": "29.0.0",
@@ -12222,6 +12280,21 @@
         }
       }
     },
+    "openapi3-ts": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.1.2.tgz",
+      "integrity": "sha512-B7gOkwsYMZO7BZXwJzXCuVagym2xhqsrilVvV0dnq2Di4+iLUXKVX9gOK23ZqaAHZOwABXN0QTdW8QnkUTX6DA==",
+      "requires": {
+        "yaml": "^2.2.2"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+          "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ=="
+        }
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -13310,6 +13383,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@rollup/plugin-typescript": "^10.0.1",
     "@types/jest": "^29.0.0",
     "@types/node": "^20.3.1",
+    "@types/service-worker-mock": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",
     "@typescript-eslint/parser": "^5.60.0",
     "eslint": "^8.43.0",
@@ -84,7 +85,9 @@
     "typescript": "^5.1.3"
   },
   "dependencies": {
-    "itty-router": "^4.0.13"
+    "@asteasolutions/zod-to-openapi": "^5.3.1",
+    "itty-router": "^4.0.14",
+    "zod": "^3.21.4"
   },
   "exports": {
     ".": {
@@ -121,6 +124,11 @@
       "import": "./dist/ui.mjs",
       "require": "./dist/ui.js",
       "types": "./dist/ui.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils.mjs",
+      "require": "./dist/utils.js",
+      "types": "./dist/utils.d.ts"
     }
   }
 }

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -52,7 +52,7 @@ export default async () => {
       },
     ],
     plugins: [
-      typescript({ sourceMap: true }),
+      typescript({ sourceMap: false }),
       terser(),
       bundleSize(),
       copy({
@@ -64,6 +64,6 @@ export default async () => {
         ],
       }),
     ],
-    external: ['itty-router'],
+    external: ['itty-router', 'zod', '@asteasolutions/zod-to-openapi'],
   }))
 }

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -1,594 +1,233 @@
-import { ValidationError } from './exceptions'
 import {
   EnumerationParameterType,
-  ParameterBody,
   ParameterLocation,
   ParameterType,
   RegexParameterType,
-  ResponseSchema,
-  StringParameterType,
 } from './types'
+import { z, ZodObject } from 'zod'
+import { isSpecificZodType, legacyTypeIntoZod } from './zod/utils'
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi'
 
-export class BaseParameter {
-  public static isParameter = true
-  public isParameter = true
-  type = 'string'
-  public params: ParameterType
-  public generated: boolean
-
-  constructor(params?: ParameterType) {
-    this.params = params || {}
-    this.generated = true
-
-    if (this.params.required === undefined) this.params.required = true
-  }
-
-  getValue() {
-    const value: Record<string, any> = {
-      type: this.type,
-      description: this.params.description,
-      example: this.params.example,
-      default: this.params.default,
-    }
-
-    if (this.params.deprecated) value.deprecated = this.params.deprecated
-
-    return value
-  }
-
-  validate(value: any): any {
-    return value
-  }
+if (z.string().openapi === undefined) {
+  // console.log('zod extension applied')
+  extendZodWithOpenApi(z)
 }
 
-export class Arr extends BaseParameter {
-  public isArr = true
-  private innerType
+// @ts-ignore
+export function convertParams(field, params) {
+  params = params || {}
+  // console.log(z.coerce.date().isOptional())
+  if (params.required === false)
+    // @ts-ignore
+    field = field.optional().transform((val) => val || null)
+
+  if (params.description) field = field.describe(params.description)
+
+  if (params.default)
+    // @ts-ignore
+    field = field.default(params.default)
+
+  return field
+}
+
+export class Arr {
+  static generator = true
 
   constructor(innerType: any, params?: ParameterType) {
-    super(params)
-    this.innerType = innerType
-  }
-
-  validate(value: any): any {
-    value = super.validate(value)
-
-    if (this.params.required === false && (value === null || value === '')) {
-      return null
-    }
-
-    if (Array.isArray(value)) {
-      value = value.map((val) => {
-        return this.innerType.validate(val)
-      })
-    } else {
-      value = [this.innerType.validate(value)]
-    }
-
-    return value
-  }
-
-  // @ts-ignore
-  getValue() {
-    return {
-      type: 'array',
-      items: this.innerType.getValue(),
-    }
+    return convertParams(legacyTypeIntoZod(innerType[0]).array(), params)
   }
 }
 
-export class Obj extends BaseParameter {
-  public isObj = true
+export class Obj {
+  static generator = true
 
-  private fields: Record<string, BaseParameter>
+  constructor(fields: object, params?: ParameterType) {
+    const parsed: Record<string, any> = {}
+    for (const [key, value] of Object.entries(fields)) {
+      parsed[key] = legacyTypeIntoZod(value)
+    }
+    // console.log(parsed)
 
-  constructor(fields: Record<string, BaseParameter>, params?: ParameterType) {
-    super(params) // TODO: fix obj params
-    this.fields = fields
+    return convertParams(z.object(parsed), params)
   }
+}
 
-  validate(value: any): any {
-    value = super.validate(value)
+export class Num {
+  static generator = true
 
-    for (const [key, param] of Object.entries(this.fields)) {
-      try {
-        if (value[key] === undefined || value[key] === null) {
-          if (param.params.required) {
-            throw new ValidationError('is required')
-          }
-        } else {
-          value[key] = param.validate(value[key])
-        }
-      } catch (e) {
+  constructor(params?: ParameterType) {
+    return convertParams(z.coerce.number(), params)
+  }
+}
+
+export class Int {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(z.coerce.number().int(), params)
+  }
+}
+
+export class Str {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(z.string(), params)
+  }
+}
+
+export class DateTime {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(z.string().datetime(), params)
+  }
+}
+
+export class Regex {
+  static generator = true
+
+  constructor(params: RegexParameterType) {
+    return convertParams(
+      // @ts-ignore
+      z.string().regex(params.pattern),
+      params
+    )
+  }
+}
+
+export class Email {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(z.string().email(), params)
+  }
+}
+
+export class Uuid {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(z.string().uuid(), params)
+  }
+}
+
+export class Hostname {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(
+      z
+        .string()
+        .regex(
+          /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/
+        ),
+      params
+    )
+  }
+}
+
+export class Ipv4 {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(z.coerce.string().ip({ version: 'v4' }), params)
+  }
+}
+
+export class Ipv6 {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(z.string().ip({ version: 'v6' }), params)
+  }
+}
+
+export class DateOnly {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(z.coerce.date(), params)
+  }
+}
+
+export class Bool {
+  static generator = true
+
+  constructor(params?: ParameterType) {
+    return convertParams(
+      z.coerce
+        .string()
+        .toLowerCase()
+        .pipe(z.enum(['true', 'false']).transform((val) => val === 'true')),
+      params
+    ).openapi({
+      type: 'boolean',
+    })
+  }
+}
+
+export class Enumeration {
+  static generator = true
+
+  constructor(params: EnumerationParameterType) {
+    let { values } = params
+    const originalValues = { ...values }
+
+    if (Array.isArray(values))
+      values = Object.fromEntries(values.map((x) => [x, x]))
+
+    if (params.enumCaseSensitive === false) {
+      values = Object.keys(values).reduce((accumulator, key) => {
         // @ts-ignore
-        e.key = (e.key || '') + `.${key}`
-
-        throw e
-      }
+        accumulator[key.toLowerCase()] = values[key]
+        return accumulator
+      }, {})
     }
 
-    return value
-  }
+    const keys: [string, ...string[]] = Object.keys(values) as [
+      string,
+      ...string[]
+    ]
 
-  // @ts-ignore
-  getValue() {
-    const result: Record<string, any> = {
-      type: 'object',
-      properties: {},
-    }
-    const required = []
-
-    for (const [key, value] of Object.entries(this.fields)) {
-      if (value.params?.required === true) {
-        required.push(key)
-      }
-
-      if (value.getValue) {
-        result.properties[key] = value.getValue()
-      } else {
-        result.properties[key] = value
-      }
+    let field
+    if ([undefined, true].includes(params.enumCaseSensitive)) {
+      field = z.enum(keys)
+    } else {
+      field = z.preprocess((val) => String(val).toLowerCase(), z.enum(keys))
     }
 
-    if (required.length > 0) {
-      result.required = required
-    }
+    field = field.transform((val) => values[val])
 
-    if (this.params.xml) {
-      result.xml = this.params.xml
-    }
+    const result = convertParams(field, params)
+    result.values = originalValues
 
     return result
   }
 }
 
-export class Num extends BaseParameter {
-  type = 'number'
-
-  validate(value: any): any {
-    value = super.validate(value)
-
-    value = Number.parseFloat(value)
-
-    if (isNaN(value)) {
-      throw new ValidationError('is not a valid number')
-    }
-
-    return value
+export function Query(type: any, params: ParameterLocation = {}) {
+  return {
+    name: params.name,
+    location: 'query',
+    type: legacyTypeIntoZod(type, params),
   }
 }
 
-export class Int extends Num {
-  type = 'integer'
-
-  validate(value: any): any {
-    value = super.validate(value)
-
-    value = Number.parseInt(value)
-
-    if (isNaN(value)) {
-      throw new ValidationError('is not a valid integer')
-    }
-
-    return value
+export function Path(type: any, params: ParameterLocation = {}) {
+  return {
+    name: params.name,
+    location: 'params',
+    type: legacyTypeIntoZod(type, params),
   }
 }
 
-export class Str extends BaseParameter {
-  type = 'string'
-  public declare params: StringParameterType
-
-  constructor(params?: StringParameterType) {
-    super(params)
+export function Header(type: any, params: ParameterLocation = {}) {
+  return {
+    name: params.name,
+    location: 'header',
+    type: legacyTypeIntoZod(type, params),
   }
-
-  validate(value: any): any {
-    value = super.validate(value)
-
-    if (typeof value !== 'string') {
-      value = value.toString()
-    }
-
-    if (this.params.format) {
-      if (this.params.format === 'date-time') {
-        value = new Date(value)
-
-        if (isNaN(value.getDay())) {
-          throw new ValidationError('is not a valid date time')
-        }
-      } else if (this.params.format === 'date') {
-        if (!value.match(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/)) {
-          throw new ValidationError('is not a valid date')
-        }
-
-        value = new Date(value)
-
-        if (isNaN(value.getDay())) {
-          throw new ValidationError('is not a valid date')
-        }
-      }
-      // TODO: validate remaining formats
-    }
-
-    return value
-  }
-
-  getValue() {
-    return {
-      ...super.getValue(),
-      format: this.params.format,
-    }
-  }
-}
-
-export class DateTime extends Str {
-  type = 'string'
-  public declare params: StringParameterType
-
-  constructor(params?: StringParameterType) {
-    super({
-      example: '2022-09-15T00:00:00Z',
-      ...params,
-      format: 'date-time',
-    })
-  }
-}
-
-export class Regex extends Str {
-  type = 'string'
-  public declare params: RegexParameterType
-
-  constructor(params: RegexParameterType) {
-    super(params)
-  }
-
-  validate(value: any): any {
-    value = super.validate(value)
-
-    if (!value.match(this.params.pattern)) {
-      if (this.params.patternError) {
-        throw new ValidationError(`is not a valid ${this.params.patternError}`)
-      }
-      throw new ValidationError(
-        `does not match the pattern ${this.params.format}`
-      )
-    }
-
-    return value
-  }
-
-  getValue() {
-    return {
-      ...super.getValue(),
-      pattern: this.params.pattern,
-    }
-  }
-}
-
-export class Email extends Regex {
-  type = 'string'
-  public declare params: RegexParameterType
-
-  constructor(params?: StringParameterType) {
-    super({
-      pattern: '^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$',
-      patternError: 'email',
-      ...params,
-      format: 'email',
-    })
-  }
-}
-
-export class Uuid extends Regex {
-  type = 'string'
-  public declare params: RegexParameterType
-
-  constructor(params?: StringParameterType) {
-    super({
-      pattern:
-        '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
-      patternError: 'uuid',
-      ...params,
-      format: 'uuid',
-    })
-  }
-}
-
-export class Hostname extends Regex {
-  type = 'string'
-  public declare params: RegexParameterType
-
-  constructor(params?: StringParameterType) {
-    super({
-      pattern:
-        '^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$',
-      patternError: 'hostname',
-      ...params,
-      format: 'hostname',
-    })
-  }
-}
-
-export class Ipv4 extends Regex {
-  type = 'string'
-  public declare params: RegexParameterType
-
-  constructor(params?: StringParameterType) {
-    super({
-      pattern:
-        '^(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}$',
-      patternError: 'ipv4',
-      ...params,
-      format: 'ipv4',
-    })
-  }
-}
-
-export class Ipv6 extends Regex {
-  type = 'string'
-  public declare params: RegexParameterType
-
-  constructor(params?: StringParameterType) {
-    super({
-      pattern:
-        '^(?:(?:[a-fA-F\\d]{1,4}:){7}(?:[a-fA-F\\d]{1,4}|:)|(?:[a-fA-F\\d]{1,4}:){6}(?:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}|:[a-fA-F\\d]{1,4}|:)|(?:[a-fA-F\\d]{1,4}:){5}(?::(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}|(?::[a-fA-F\\d]{1,4}){1,2}|:)|(?:[a-fA-F\\d]{1,4}:){4}(?:(?::[a-fA-F\\d]{1,4}){0,1}:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}|(?::[a-fA-F\\d]{1,4}){1,3}|:)|(?:[a-fA-F\\d]{1,4}:){3}(?:(?::[a-fA-F\\d]{1,4}){0,2}:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}|(?::[a-fA-F\\d]{1,4}){1,4}|:)|(?:[a-fA-F\\d]{1,4}:){2}(?:(?::[a-fA-F\\d]{1,4}){0,3}:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}|(?::[a-fA-F\\d]{1,4}){1,5}|:)|(?:[a-fA-F\\d]{1,4}:){1}(?:(?::[a-fA-F\\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}|(?::[a-fA-F\\d]{1,4}){1,6}|:)|(?::(?:(?::[a-fA-F\\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}|(?::[a-fA-F\\d]{1,4}){1,7}|:)))(?:%[0-9a-zA-Z]{1,})?$',
-      patternError: 'ipv6',
-      ...params,
-      format: 'ipv6',
-    })
-  }
-}
-
-export class DateOnly extends Str {
-  type = 'string'
-  public declare params: StringParameterType
-
-  constructor(params?: StringParameterType) {
-    super({
-      example: '2022-09-15',
-      ...params,
-      format: 'date',
-    })
-  }
-}
-
-export class Bool extends Str {
-  type = 'boolean'
-  private validValues = ['true', 'false']
-
-  validate(value: any): any {
-    value = super.validate(value)
-
-    value = value.toLowerCase()
-
-    if (!this.validValues.includes(value)) {
-      throw new ValidationError(
-        'is not a valid boolean, allowed values are true or false'
-      )
-    }
-
-    value = value === 'true'
-
-    return value
-  }
-}
-
-export class Enumeration extends Str {
-  public isEnum = true
-  public declare params: EnumerationParameterType
-  public values: Record<string, any>
-  public keys: any
-
-  constructor(params: EnumerationParameterType) {
-    super(params)
-
-    let { values } = params
-    if (Array.isArray(values))
-      values = Object.fromEntries(values.map((x) => [x, x]))
-    this.keys = Object.keys(values)
-    this.values = values
-  }
-
-  validate(value: any): any {
-    value = super.validate(value)
-
-    if (this.params.enumCaseSensitive !== false) {
-      value = this.params.values[value]
-    } else {
-      const key = this.keys.find(
-        (key: any) => key.toLowerCase() === value.toLowerCase()
-      )
-      value = this.params.values[key]
-    }
-
-    if (value === undefined) {
-      if (this.params.required === true) {
-        throw new ValidationError('is not one of available options')
-      }
-
-      // Parameter not required neither one of the available options
-      return null
-    }
-
-    return value
-  }
-
-  getValue() {
-    return {
-      ...super.getValue(),
-      enum: this.keys,
-    }
-  }
-}
-
-export class Parameter {
-  public location: string
-  private rawType: any
-  public type: BaseParameter
-  public params: ParameterLocation
-
-  constructor(location: string, rawType: any, params: ParameterLocation) {
-    this.location = location
-    this.rawType = rawType
-
-    if (params.required === undefined) params.required = true
-    this.params = params
-
-    this.type = this.getType(rawType, params)
-  }
-
-  getType(type: any, params: ParameterLocation): any {
-    if (type.generated === true) {
-      return type
-    }
-
-    if (type.isParameter === true) {
-      // @ts-ignore
-      return new type({ ...params })
-    }
-
-    if (type === String) {
-      return new Str({ ...params })
-    }
-
-    if (typeof type === 'string') {
-      return new Str({ example: type })
-    }
-
-    if (type === Number) {
-      return new Num({ ...params })
-    }
-
-    if (typeof type === 'number') {
-      return new Num({ example: type })
-    }
-
-    if (type === Boolean) {
-      return new Bool({ ...params })
-    }
-
-    if (typeof type === 'boolean') {
-      return new Bool({ example: type })
-    }
-
-    if (type === Date) {
-      return new DateTime()
-    }
-
-    if (Array.isArray(type)) {
-      if (type.length === 0) {
-        throw new Error('Arr must have a type')
-      }
-
-      return new Arr(this.getType(type[0], params), { ...params })
-    }
-
-    if (typeof type === 'object') {
-      const parsed: Record<string, any> = {}
-      for (const [key, value] of Object.entries(type)) {
-        parsed[key] = this.getType(value, {})
-      }
-
-      return new Obj(parsed, params)
-    }
-
-    throw new Error(`${type} not implemented`)
-  }
-
-  getValue(): Record<string, any> {
-    const schema = removeUndefinedFields(this.type.getValue())
-
-    return {
-      description: this.params.description,
-      required: this.params.required,
-      schema: schema,
-      name: this.params.name,
-      in: this.location,
-    }
-  }
-
-  validate(value: any): any {
-    if (value === undefined || value === null) {
-      if (this.params.default !== undefined && this.params.default !== null) {
-        value = this.params.default
-      } else {
-        if (this.params.required) {
-          throw new ValidationError('is required')
-        } else {
-          return null
-        }
-      }
-    }
-
-    value = this.type.validate(value)
-
-    return value
-  }
-}
-
-export class Body extends Parameter {
-  paramsBody: ParameterBody
-
-  constructor(rawType: any, params?: ParameterBody) {
-    // @ts-ignore
-    super(null, rawType, {})
-    // @ts-ignore
-    this.paramsBody = params
-  }
-
-  getValue(): Record<string, any> {
-    const schema = removeUndefinedFields(this.type.getValue())
-
-    const param: Record<string, any> = {
-      description: this.paramsBody?.description,
-      content: {},
-    }
-
-    param.content[this.paramsBody?.contentType || 'application/json'] = {
-      schema: schema,
-    }
-
-    return param
-  }
-}
-
-export class Resp extends Parameter {
-  constructor(rawType: any, params: ResponseSchema) {
-    // @ts-ignore
-    super(null, rawType, params)
-  }
-
-  // @ts-ignore
-  getValue() {
-    const value = super.getValue()
-    const contentType = this.params?.contentType
-      ? this.params?.contentType
-      : 'application/json'
-
-    const param: Record<string, any> = {
-      description: this.params.description || 'Successful Response',
-      content: {},
-    }
-
-    param.content[contentType] = { schema: value.schema }
-    return param
-  }
-}
-
-export function Query(type: any, params: ParameterLocation = {}): Parameter {
-  return new Parameter('query', type, params)
-}
-
-export function Path(type: any, params: ParameterLocation = {}): Parameter {
-  return new Parameter('path', type, params)
-}
-
-export function Header(type: any, params: ParameterLocation = {}): Parameter {
-  return new Parameter('header', type, params)
-}
-
-export function Cookie(type: any, params: ParameterLocation = {}): Parameter {
-  return new Parameter('cookie', type, params)
 }
 
 export function extractParameter(
@@ -613,20 +252,28 @@ export function extractParameter(
   }
 }
 
-export function extractQueryParameters(request: Request): Record<string, any> {
+export function extractQueryParameters(
+  request: Request,
+  schema?: ZodObject<any>
+): Record<string, any> | null {
   const url = decodeURIComponent(request.url).split('?')
 
   if (url.length === 1) {
-    return {}
+    return null
   }
 
-  const query = url.slice(1).join('?')
+  let query = url.slice(1).join('?')
+
+  // RFC 3986 allows query string to start with &
+  if (query.startsWith('&')) {
+    query = query.substring(1)
+  }
 
   const params: Record<string, any> = {}
   for (const param of query.split('&')) {
-    const paramSplitted = param.split('=')
-    const key = paramSplitted[0]
-    const value = paramSplitted[1]
+    const paramSplit = param.split('=')
+    const key = paramSplit[0]
+    const value = paramSplit[1]
 
     if (params[key] === undefined) {
       params[key] = value
@@ -635,44 +282,36 @@ export function extractQueryParameters(request: Request): Record<string, any> {
     } else {
       params[key].push(value)
     }
+
+    // Soft transform query strings into arrays
+    if (schema && schema.shape[key]) {
+      if (
+        isSpecificZodType(schema.shape[key], 'ZodArray') &&
+        !Array.isArray(params[key])
+      ) {
+        params[key] = [params[key]]
+      } else if (isSpecificZodType(schema.shape[key], 'ZodBoolean')) {
+        // z.preprocess(
+        // (val) => String(val).toLowerCase(),
+        // z.enum(['true', 'false']).transform((val) => val === 'true')
+        // ),
+      }
+    }
   }
 
   return params
 }
 
-export function Required(param: Parameter): Parameter {
-  param.params.required = true
-
-  return param
-}
-
-export function removeUndefinedFields(
-  obj: Record<string, any>
-): Record<string, any> {
-  for (const [key, value] of Object.entries(obj)) {
-    if (typeof value === 'object' && !Array.isArray(value))
-      obj[key] = removeUndefinedFields(value)
-
-    if (value === undefined) {
-      delete obj[key]
-    }
-  }
-
-  return obj
-}
-
-export function getFormatedParameters(
-  params: Record<string, Parameter> | Parameter[]
-) {
+export function genParametersForUnknownEndpoint(params: Record<any, any>) {
   const formated = []
   const isArray = Array.isArray(params)
 
   for (const [key, parameter] of Object.entries(params || {})) {
-    if (isArray && !parameter.params.name) {
+    if (isArray && !parameter.name) {
       throw new Error('Parameter must have a defined name when using as Array')
     }
 
-    const name = parameter.params.name ? parameter.params.name : key
+    const name = parameter.name || key
 
     formated.push({
       // TODO: check this type before assign

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import { Parameter } from './parameters'
 import { RequestLike, Route, RouteEntry, RouterType } from 'itty-router'
 
 export interface ClassRoute {
@@ -33,6 +32,7 @@ export interface RouterOptions {
   aiPlugin?: AIPlugin
   raiseUnknownParameters?: boolean
   generateOperationIds?: boolean
+  openapiVersion?: '3' | '3.1'
 }
 
 export interface RouteOptions {
@@ -45,13 +45,14 @@ export interface OpenAPISchema {
   description?: string
   operationId?: string
   requestBody?: Record<string, any>
-  parameters?: Record<string, Parameter> | Parameter[]
-  responses?: Record<string, ResponseSchema>
+  parameters?: Record<string, any>
+  responses?: Record<string | number, ResponseSchema>
   deprecated?: boolean
 }
 
 export interface OpenAPIRouteSchema {
   getSchema(): OpenAPISchema
+
   schema: OpenAPISchema
 }
 
@@ -78,7 +79,7 @@ export interface EnumerationParameterType extends StringParameterType {
 }
 
 export interface RegexParameterType extends StringParameterType {
-  pattern: string
+  pattern: RegExp
   patternError?: string
 }
 
@@ -90,7 +91,7 @@ export interface ParameterLocation extends StringParameterType {
   // Because this is a generic initializer, it must include all available options
   values?: Record<string, any>
   enumCaseSensitive?: boolean
-  pattern?: string
+  pattern?: string | RegExp
   patternError?: string
 }
 
@@ -100,7 +101,7 @@ export interface ParameterBody {
 }
 
 export interface ResponseSchema {
-  description?: string
+  description: string
   schema?: Record<any, any>
   contentType?: string
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -7,13 +7,13 @@ export function getSwaggerUI(schemaUrl: string): string {
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="description" content="SwaggerIU"/>
     <title>SwaggerUI</title>
-    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.1.3/swagger-ui.css"/>
     <link rel="shortcut icon" href="data:image/x-icon;base64,AAABAAEAEBAAAAEAIABoBAAAFgAAACgAAAAQAAAAIAAAAAEAIAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlMb//2ux//9or///ZKz//wlv5f8JcOf/CnXv/why7/8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB2vi/wZo3/9ytf//b7P//2uw//+BvP//DHbp/w568P8Md+//CnXv/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApv4/8HbOH/lMf//3W3//9ytf//brL//w946v8SfvH/EHzw/w558P8AAAAAAAAAAAAAAAAAAAAAAAAAABF56f8Ndef/C3Dj/whs4f98u///eLn//3W3//+Evv//FoPx/xSA8f8SfvD/EHvw/wAAAAAAAAAAAAAAAA1EeF0WgOz/EXrp/w515v8LceT/lsn//3+9//97u///eLj//xaB7f8YhfL/FoLx/xSA8f8JP/deAAAAAAAAAAAgjfH/HIjw/xeB7P8Te+n/AAAAAAAAAACGwf//gr///369//+Iwf//HIny/xqH8v8YhfL/FYLx/wAAAAAnlfPlJJLy/yGO8v8cifD/GILt/wAAAAAAAAAAmMz//4nD//+Fwf//gb///xyJ8P8ejPP/HIny/xmH8v8XhPLnK5r0/yiW8/8lk/P/IpDy/wAAAAAAAAAAAAAAAAAAAACPx///jMX//4jD//+MxP//IpD0/yCO8/8di/P/G4ny/y6e9f8sm/T/KZj0/yaV8/8AAAAAAAAAAAAAAAAAAAAAlsz//5LJ//+Px///lMn//yaV9P8kkvT/IZD0/x+O8/8yo/blMKD1/y2d9f8qmfT/KJbz/wAAAAAAAAAAqdb//53Q//+Zzv//lsv//yiY8/8qmvX/KJf1/yWV9P8jkvTQAAAAADSl9v8xofX/Lp71/yyb9P8AAAAAAAAAAKfW//+k1P//oNL//6rW//8wofb/Lp72/yuc9f8pmfX/AAAAAAAAAAAcVHtcNab2/zKj9v8voPX/LZz0/7vh//+u2///qtj//6fW//8wofT/NKX3/zKj9/8voPb/F8/6XgAAAAAAAAAAAAAAADmr9/82qPf/M6T2/zCg9f+44f//td///7Hd//++4v//Oqz4/ziq+P81p/f/M6X3/wAAAAAAAAAAAAAAAAAAAAAAAAAAOqz4/zep9//M6///v+X//7vj//+44f//OKn1/z6x+f88rvn/Oaz4/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD6x+f8qmfP/yOv//8bq///C5///z+z//0O3+v9Ctfr/QLP5/z2x+f8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0u///8jr///I6///yOv//zmq9f9Dt/r/Q7f6/0O3+v8AAAAAAAAAAAAAAAAAAAAA8A8AAOAHAADgBwAAwAMAAMADAACGAQAABgAAAA8AAAAPAAAABgAAAIYBAADAAwAAwAMAAOAHAADgBwAA8A8AAA==" />
 </head>
 <body>
 <div id="swagger-ui"></div>
-<script src="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-bundle.js" crossorigin></script>
-<script src="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-standalone-preset.js" crossorigin></script>
+<script src="https://unpkg.com/swagger-ui-dist@5.1.3/swagger-ui-bundle.js" crossorigin></script>
+<script src="https://unpkg.com/swagger-ui-dist@5.1.3/swagger-ui-standalone-preset.js" crossorigin></script>
 <script>
     window.onload = () => {
         window.ui = SwaggerUIBundle({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,10 @@
+export function jsonResp(data: object, params?: object): Response {
+  return new Response(JSON.stringify(data), {
+    headers: {
+      'content-type': 'application/json;charset=UTF-8',
+    },
+    // @ts-ignore
+    status: params?.status ? params.status : 200,
+    ...params,
+  })
+}

--- a/src/zod/registry.ts
+++ b/src/zod/registry.ts
@@ -1,0 +1,13 @@
+import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi'
+import { OpenAPIDefinitions } from '@asteasolutions/zod-to-openapi/dist/openapi-registry'
+
+// @ts-ignore
+export class OpenAPIRegistryMerger extends OpenAPIRegistry {
+  public _definitions: OpenAPIDefinitions[] = []
+
+  merge(registry: OpenAPIRegistryMerger): void {
+    for (const definition of registry._definitions) {
+      this._definitions.push({ ...definition })
+    }
+  }
+}

--- a/src/zod/utils.ts
+++ b/src/zod/utils.ts
@@ -1,0 +1,87 @@
+import type { z } from 'zod'
+import {
+  Arr,
+  Bool,
+  convertParams,
+  DateTime,
+  Num,
+  Obj,
+  Str,
+} from '../parameters'
+
+export function isAnyZodType(schema: object): schema is z.ZodType {
+  // @ts-ignore
+  return schema._def !== undefined
+}
+
+export function isSpecificZodType(field: any, typeName: string): boolean {
+  return (
+    field._def.typeName === 'ZodArray' ||
+    field._def.innerType?._def.typeName === 'ZodArray' ||
+    field._def.schema?._def.innerType?._def.typeName === 'ZodArray'
+  )
+}
+
+export function legacyTypeIntoZod(type: any, params?: any): any {
+  params = params || {}
+
+  if (isAnyZodType(type)) {
+    if (params) {
+      return convertParams(type, params)
+    }
+
+    return type
+  }
+
+  // Legacy support
+  if (type.generator === true) {
+    return new type(params)
+  }
+
+  if (type === String) {
+    // console.log(1)
+    // console.log(type)
+    // console.log(params)
+    const asd = new Str(params)
+    // console.log(asd)
+    return asd
+  }
+
+  if (typeof type === 'string') {
+    return new Str({ example: type })
+  }
+
+  if (type === Number) {
+    return new Num(params)
+  }
+
+  if (typeof type === 'number') {
+    return new Num({ example: type })
+  }
+
+  if (type === Boolean) {
+    return new Bool(params)
+  }
+
+  if (typeof type === 'boolean') {
+    return new Bool({ example: type })
+  }
+
+  if (type === Date) {
+    return new DateTime(params)
+  }
+
+  if (Array.isArray(type)) {
+    if (type.length === 0) {
+      throw new Error('Arr must have a type')
+    }
+
+    return new Arr(type, params)
+  }
+
+  if (typeof type === 'object') {
+    return new Obj(type, params)
+  }
+
+  throw new Error(`${type} not implemented`)
+}

--- a/tests/integration/nested-routers.test.ts
+++ b/tests/integration/nested-routers.test.ts
@@ -4,6 +4,7 @@ import { OpenAPIRoute } from '../../src/route'
 import { Path } from '../../src/parameters'
 import { OpenAPIRouter } from '../../src/openapi'
 import { buildRequest } from '../utils'
+import { jsonResp } from '../../src/utils'
 
 const innerRouter = OpenAPIRouter({ base: '/api/v1' })
 class ToDoGet extends OpenAPIRoute {
@@ -15,6 +16,7 @@ class ToDoGet extends OpenAPIRoute {
     },
     responses: {
       '200': {
+        description: 'example',
         schema: {
           todo: {
             lorem: String,
@@ -41,9 +43,7 @@ class ToDoGet extends OpenAPIRoute {
 }
 
 innerRouter.get('/todo/:id', ToDoGet)
-innerRouter.all('*', () =>
-  Response.json({ message: 'Not Found' }, { status: 404 })
-)
+innerRouter.all('*', () => jsonResp({ message: 'Not Found' }, { status: 404 }))
 
 const router = OpenAPIRouter({
   schema: {

--- a/tests/integration/parameters.test.ts
+++ b/tests/integration/parameters.test.ts
@@ -1,5 +1,5 @@
 import 'isomorphic-fetch'
-import { buildRequest } from '../utils'
+import { buildRequest, findError } from '../utils'
 import { ToDoList, todoRouter } from '../router'
 
 describe('queryParametersValidation', () => {
@@ -10,13 +10,17 @@ describe('queryParametersValidation', () => {
     const resp = await request.json()
 
     // minus 1, because 1 parameter is optional
-    expect(Object.keys(resp.errors).length).toEqual(
+    expect(resp.errors.length).toEqual(
       Object.keys(ToDoList.schema.parameters).length - 1
     )
 
     // sanity check some parameters
-    expect(resp.errors.p_number).toEqual('is required')
-    expect(resp.errors.p_boolean).toEqual('is required')
+    expect(findError(resp.errors, 'p_number')).toEqual(
+      'Expected number, received nan'
+    )
+    expect(findError(resp.errors, 'p_boolean')).toEqual(
+      "Invalid enum value. Expected 'true' | 'false', received 'undefined'"
+    )
   })
 
   test('checkNumberInvalid', async () => {
@@ -26,7 +30,9 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_number).toEqual('is not a valid number')
+    expect(findError(resp.errors, 'p_number')).toEqual(
+      'Expected number, received nan'
+    )
   })
 
   test('checkNumberValidFloat', async () => {
@@ -36,7 +42,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_number).toBeUndefined()
+    expect(findError(resp.errors, 'p_number')).toBeUndefined()
   })
 
   test('checkNumberValidInteger', async () => {
@@ -46,7 +52,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_number).toBeUndefined()
+    expect(findError(resp.errors, 'p_number')).toBeUndefined()
   })
 
   test('checkStringValid', async () => {
@@ -56,7 +62,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_string).toBeUndefined()
+    expect(findError(resp.errors, 'p_string')).toBeUndefined()
   })
 
   test('checkBooleanInvalid', async () => {
@@ -66,8 +72,8 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_boolean).toEqual(
-      'is not a valid boolean, allowed values are true or false'
+    expect(findError(resp.errors, 'p_boolean')).toEqual(
+      "Invalid enum value. Expected 'true' | 'false', received 'asd'"
     )
   })
 
@@ -78,7 +84,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_boolean).toBeUndefined()
+    expect(findError(resp.errors, 'p_boolean')).toBeUndefined()
   })
 
   test('checkBooleanValidCaseInsensitive', async () => {
@@ -88,7 +94,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_boolean).toBeUndefined()
+    expect(findError(resp.errors, 'p_boolean')).toBeUndefined()
   })
 
   test('checkEnumerationSensitiveInvalid', async () => {
@@ -98,7 +104,9 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_enumeration).toEqual('is not one of available options')
+    expect(findError(resp.errors, 'p_enumeration')).toEqual(
+      "Invalid enum value. Expected 'json' | 'csv', received 'sfDase'"
+    )
   })
 
   test('checkEnumerationSensitiveInvalidCase', async () => {
@@ -108,7 +116,9 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_enumeration).toEqual('is not one of available options')
+    expect(findError(resp.errors, 'p_enumeration')).toEqual(
+      "Invalid enum value. Expected 'json' | 'csv', received 'Csv'"
+    )
   })
 
   test('checkEnumerationSensitiveValid', async () => {
@@ -118,7 +128,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_enumeration).toBeUndefined()
+    expect(findError(resp.errors, 'p_enumeration')).toBeUndefined()
   })
 
   test('checkEnumerationInsensitiveInvalid', async () => {
@@ -128,8 +138,8 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_enumeration_insensitive).toEqual(
-      'is not one of available options'
+    expect(findError(resp.errors, 'p_enumeration_insensitive')).toEqual(
+      "Invalid enum value. Expected 'json' | 'csv', received 'sfdase'"
     )
   })
 
@@ -140,7 +150,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_enumeration_insensitive).toBeUndefined()
+    expect(findError(resp.errors, 'p_enumeration_insensitive')).toBeUndefined()
   })
 
   test('checkEnumerationInsensitiveValid', async () => {
@@ -150,7 +160,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_enumeration_insensitive).toBeUndefined()
+    expect(findError(resp.errors, 'p_enumeration_insensitive')).toBeUndefined()
   })
 
   test('checkDatetimeInvalid', async () => {
@@ -160,7 +170,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_datetime).toEqual('is not a valid date time')
+    expect(findError(resp.errors, 'p_datetime')).toEqual('Invalid datetime')
   })
 
   test('checkDatetimeInvalid2', async () => {
@@ -170,7 +180,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_datetime).toEqual('is not a valid date time')
+    expect(findError(resp.errors, 'p_datetime')).toEqual('Invalid datetime')
   })
 
   test('checkDatetimeInvalid3', async () => {
@@ -180,17 +190,17 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_datetime).toEqual('is not a valid date time')
+    expect(findError(resp.errors, 'p_datetime')).toEqual('Invalid datetime')
   })
 
   test('checkDatetimeValid', async () => {
-    const qs = '?p_datetime=2022-09-15'
+    const qs = '?p_datetime=2022-09-15T00:00:01Z'
     const request = await todoRouter.handle(
       buildRequest({ method: 'GET', path: `/todos${qs}` })
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_datetime).toBeUndefined()
+    expect(findError(resp.errors, 'p_datetime')).toBeUndefined()
   })
 
   test('checkDatetimeValid2', async () => {
@@ -200,7 +210,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_datetime).toBeUndefined()
+    expect(findError(resp.errors, 'p_datetime')).toBeUndefined()
   })
 
   test('checkDateInvalid', async () => {
@@ -210,27 +220,17 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_dateonly).toEqual('is not a valid date')
-  })
-
-  test('checkDateInvalid2', async () => {
-    const qs = '?p_dateonly=2022-10'
-    const request = await todoRouter.handle(
-      buildRequest({ method: 'GET', path: `/todos${qs}` })
-    )
-    const resp = await request.json()
-
-    expect(resp.errors.p_dateonly).toEqual('is not a valid date')
+    expect(findError(resp.errors, 'p_dateonly')).toEqual('Invalid date')
   })
 
   test('checkDateInvalid3', async () => {
-    const qs = '?p_dateonly=2022-09-15T00:00:00Z'
+    const qs = '?p_dateonly=2022-09-15T00:0f0:00.0Z'
     const request = await todoRouter.handle(
       buildRequest({ method: 'GET', path: `/todos${qs}` })
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_dateonly).toEqual('is not a valid date')
+    expect(findError(resp.errors, 'p_dateonly')).toEqual('Invalid date')
   })
 
   test('checkDateValid', async () => {
@@ -240,7 +240,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_dateonly).toBeUndefined()
+    expect(findError(resp.errors, 'p_dateonly')).toBeUndefined()
   })
 
   test('checkRegexInvalid', async () => {
@@ -250,9 +250,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(
-      resp.errors.p_regex.includes('does not match the pattern')
-    ).toBeTruthy()
+    expect(findError(resp.errors, 'p_regex')).toBeTruthy()
   })
 
   test('checkRegexValid', async () => {
@@ -262,7 +260,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_regex).toBeUndefined()
+    expect(findError(resp.errors, 'p_regex')).toBeUndefined()
   })
 
   test('checkEmailInvalid', async () => {
@@ -272,7 +270,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_email).toEqual('is not a valid email')
+    expect(findError(resp.errors, 'p_email')).toEqual('Invalid email')
   })
 
   test('checkEmailInvalid2', async () => {
@@ -282,7 +280,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_email).toEqual('is not a valid email')
+    expect(findError(resp.errors, 'p_email')).toEqual('Invalid email')
   })
 
   test('checkEmailInvalid3', async () => {
@@ -292,7 +290,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_email).toEqual('is not a valid email')
+    expect(findError(resp.errors, 'p_email')).toEqual('Invalid email')
   })
 
   test('checkEmailValid', async () => {
@@ -302,7 +300,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_email).toBeUndefined()
+    expect(findError(resp.errors, 'p_email')).toBeUndefined()
   })
 
   test('checkUuidInvalid', async () => {
@@ -312,7 +310,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_uuid).toEqual('is not a valid uuid')
+    expect(findError(resp.errors, 'p_uuid')).toEqual('Invalid uuid')
   })
 
   test('checkUuidInvalid2', async () => {
@@ -322,7 +320,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_uuid).toEqual('is not a valid uuid')
+    expect(findError(resp.errors, 'p_uuid')).toEqual('Invalid uuid')
   })
 
   test('checkUuidValid', async () => {
@@ -332,7 +330,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_uuid).toBeUndefined()
+    expect(findError(resp.errors, 'p_uuid')).toBeUndefined()
   })
 
   test('checkUuidValid2', async () => {
@@ -342,7 +340,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_uuid).toBeUndefined()
+    expect(findError(resp.errors, 'p_uuid')).toBeUndefined()
   })
 
   test('checkHostnameInvalid', async () => {
@@ -352,7 +350,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_hostname).toEqual('is not a valid hostname')
+    expect(findError(resp.errors, 'p_hostname')).toEqual('Invalid')
   })
 
   test('checkHostnameValid', async () => {
@@ -362,7 +360,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_hostname).toBeUndefined()
+    expect(findError(resp.errors, 'p_hostname')).toBeUndefined()
   })
 
   test('checkHostnameValid2', async () => {
@@ -372,7 +370,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_hostname).toBeUndefined()
+    expect(findError(resp.errors, 'p_hostname')).toBeUndefined()
   })
 
   test('checkIpv4Invalid', async () => {
@@ -382,7 +380,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_ipv4).toEqual('is not a valid ipv4')
+    expect(findError(resp.errors, 'p_ipv4')).toEqual('Invalid ip')
   })
 
   test('checkIpv4Invalid2', async () => {
@@ -392,7 +390,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_ipv4).toEqual('is not a valid ipv4')
+    expect(findError(resp.errors, 'p_ipv4')).toEqual('Invalid ip')
   })
 
   test('checkIpv4Valid', async () => {
@@ -402,7 +400,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_ipv4).toBeUndefined()
+    expect(findError(resp.errors, 'p_ipv4')).toBeUndefined()
   })
 
   test('checkIpv6Invalid', async () => {
@@ -412,7 +410,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_ipv6).toEqual('is not a valid ipv6')
+    expect(findError(resp.errors, 'p_ipv6')).toEqual('Invalid ip')
   })
 
   test('checkIpv6Invalid2', async () => {
@@ -422,7 +420,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_ipv6).toEqual('is not a valid ipv6')
+    expect(findError(resp.errors, 'p_ipv6')).toEqual('Invalid ip')
   })
 
   test('checkIpv6Valid', async () => {
@@ -432,7 +430,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_ipv6).toBeUndefined()
+    expect(findError(resp.errors, 'p_ipv6')).toBeUndefined()
   })
 
   test('checkOptionalMissing', async () => {
@@ -442,7 +440,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_optional).toBeUndefined()
+    expect(findError(resp.errors, 'p_optional')).toBeUndefined()
   })
 
   test('checkOptionalInvalid', async () => {
@@ -452,7 +450,9 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_optional).toEqual('is not a valid number')
+    expect(findError(resp.errors, 'p_optional')).toEqual(
+      'Expected number, received nan'
+    )
   })
 
   test('checkOptionalValid', async () => {
@@ -462,7 +462,7 @@ describe('queryParametersValidation', () => {
     )
     const resp = await request.json()
 
-    expect(resp.errors.p_optional).toBeUndefined()
+    expect(findError(resp.errors, 'p_optional')).toBeUndefined()
   })
 })
 
@@ -482,7 +482,7 @@ describe('bodyParametersValidation', () => {
     expect(request.status).toEqual(400)
 
     // the current body implementation only validates 1 field at time
-    expect(resp.errors['body.title']).toEqual('is required')
+    expect(findError(resp.errors, 'title')).toEqual('Required')
   })
 
   test('requiredFieldTipe', async () => {
@@ -502,7 +502,7 @@ describe('bodyParametersValidation', () => {
     expect(request.status).toEqual(400)
 
     // the current body implementation only validates 1 field at time
-    expect(resp.errors['body.type']).toEqual('is required')
+    expect(findError(resp.errors, 'type')).toEqual('Required')
   })
 
   test('validRequest', async () => {
@@ -524,7 +524,9 @@ describe('bodyParametersValidation', () => {
 
     expect(request.status).toEqual(200)
 
-    expect(resp).toEqual({ todo: { title: 'my todo', type: 'nextWeek' } })
+    expect(resp).toEqual({
+      todo: { title: 'my todo', type: 'nextWeek', description: null },
+    })
   })
 
   test('validRequestWithOptionalParameters', async () => {

--- a/tests/integration/zod.ts
+++ b/tests/integration/zod.ts
@@ -1,0 +1,72 @@
+import 'isomorphic-fetch'
+
+import { OpenAPIRoute } from '../../src/route'
+import { Path } from '../../src/parameters'
+import { OpenAPIRouter } from '../../src/openapi'
+import { buildRequest } from '../utils'
+import { z } from 'zod'
+
+const zodRouter = OpenAPIRouter()
+
+class ToDoGet extends OpenAPIRoute {
+  static schema = {
+    tags: ['ToDo'],
+    summary: 'Get a single ToDo',
+    parameters: {
+      id: Path(z.number()),
+    },
+    requestBody: z.object({
+      title: z.string(),
+      description: z.string(), //.optional(),
+      type: z.nativeEnum({
+        nextWeek: 'nextWeek',
+        nextMonth: 'nextMonth',
+      }),
+    }),
+    responses: {
+      '200': {
+        description: 'example',
+        schema: {
+          todo: {
+            lorem: String,
+            ipsum: String,
+          },
+        },
+      },
+    },
+  }
+
+  async handle(
+    request: Request,
+    env: any,
+    context: any,
+    data: Record<string, any>
+  ) {
+    return {
+      todo: {
+        lorem: 'lorem',
+        ipsum: 'ipsum',
+      },
+    }
+  }
+}
+
+zodRouter.put('/todo/:id', ToDoGet)
+
+describe('zod validations', () => {
+  it('simpleSuccessfulCall', async () => {
+    const request = await zodRouter.handle(
+      buildRequest({ method: 'PUT', path: `/todo/1` })
+    )
+
+    const resp = await request.json()
+
+    expect(request.status).toEqual(200)
+    expect(resp).toEqual({
+      todo: {
+        lorem: 'lorem',
+        ipsum: 'ipsum',
+      },
+    })
+  })
+})

--- a/tests/router.ts
+++ b/tests/router.ts
@@ -47,7 +47,7 @@ export class ToDoList extends OpenAPIRoute {
       p_dateonly: Query(DateOnly),
       p_regex: Query(Regex, {
         pattern:
-          '^[\\+]?[(]?[0-9]{3}[)]?[-\\s\\.]?[0-9]{3}[-\\s\\.]?[0-9]{4,6}$',
+          /^[\\+]?[(]?[0-9]{3}[)]?[-\\s\\.]?[0-9]{3}[-\\s\\.]?[0-9]{4,6}$/,
       }),
       p_email: Query(Email),
       p_uuid: Query(Uuid),
@@ -60,6 +60,7 @@ export class ToDoList extends OpenAPIRoute {
     },
     responses: {
       '200': {
+        description: 'example',
         schema: {
           params: {},
           results: ['lorem'],
@@ -90,6 +91,7 @@ export class ToDoGet extends OpenAPIRoute {
     },
     responses: {
       '200': {
+        description: 'example',
         schema: {
           todo: {
             lorem: String,
@@ -131,6 +133,7 @@ export class ToDoCreate extends OpenAPIRoute {
     },
     responses: {
       '200': {
+        description: 'example',
         schema: {
           todo: {
             title: 'My new todo',
@@ -154,7 +157,7 @@ export class ToDoCreate extends OpenAPIRoute {
   }
 }
 
-export const todoRouter = OpenAPIRouter()
+export const todoRouter = OpenAPIRouter({ openapiVersion: '3' })
 todoRouter.get('/todos', ToDoList)
 todoRouter.get('/todos/:id', ToDoGet)
 todoRouter.post('/todos', ToDoCreate)

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -4,3 +4,11 @@ export const buildRequest = ({ method = 'GET', path = '/', ...other }) => ({
   url: `https://example.com${path}`,
   ...other,
 })
+
+export function findError(errors: any, field: any) {
+  for (const error of errors) {
+    if (error.path.includes(field)) {
+      return error.message
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,14 +14,14 @@
     "noFallthroughCasesInSwitch": true,
     "pretty": true,
     "resolveJsonModule": true,
-    "rootDir": "src",
+    "rootDir": "./",
     "skipLibCheck": true,
     "strict": true,
     "traceResolution": false,
     "outDir": "",
     "target": "esnext",
     "module": "esnext",
-    "types": ["@types/node", "@types/jest", "@cloudflare/workers-types", "@types/service-worker-mock"]
+    "types": ["@types/node", "@types/jest", "@types/service-worker-mock", "@cloudflare/workers-types"]
   },
   "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/example.ts"],
   "include": ["src", "tests", "example"]


### PR DESCRIPTION
This pr will add support for zod while keeping support for the older type definitions like `new Str({required: false})`

Breaking changes:
 - `Regex` now must be in the `RegExp` format instead of string, ex: `/^[\\+]?[(]?[0-9]{3}[)]?[-\\s\\.]?[0-9]{3}[-\\s\\.]?[0-9]{4,6}$/` 
 - Validation errors format is now different
 - `raiseUnknownParameters` is now default to `true`
 - query, headers and path parameters each now have its own object inside the `data` argument