### PR TITLE
parameters: Fix for Decoding Query Parameters

### DIFF
--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -617,20 +617,10 @@ export function extractParameter(
 }
 
 export function extractQueryParameters(request: Request): Record<string, any> {
-  const url = decodeURIComponent(request.url).split('?')
-
-  if (url.length === 1) {
-    return {}
-  }
-
-  const query = url.slice(1).join('?')
-
+  const { searchParams } = new URL(request.url)
   const params: Record<string, any> = {}
-  for (const param of query.split('&')) {
-    const paramSplitted = param.split('=')
-    const key = paramSplitted[0]
-    const value = paramSplitted[1]
 
+  searchParams.forEach((value, key) => {
     if (params[key] === undefined) {
       params[key] = value
     } else if (!Array.isArray(params[key])) {
@@ -638,7 +628,7 @@ export function extractQueryParameters(request: Request): Record<string, any> {
     } else {
       params[key].push(value)
     }
-  }
+  })
 
   return params
 }

--- a/tests/integration/parameters.test.ts
+++ b/tests/integration/parameters.test.ts
@@ -256,7 +256,7 @@ describe('queryParametersValidation', () => {
   })
 
   test('checkRegexValid', async () => {
-    const qs = '?p_regex=+919367788755'
+    const qs = '?p_regex=' + encodeURIComponent('+919367788755')
     const request = await todoRouter.handle(
       buildRequest({ method: 'GET', path: `/todos${qs}` })
     )

--- a/tests/router.ts
+++ b/tests/router.ts
@@ -23,18 +23,33 @@ export class ToDoList extends OpenAPIRoute {
     tags: ['ToDo'],
     summary: 'List all ToDos',
     parameters: {
-      p_number: Query(Number),
-      p_string: Query(String),
-      p_boolean: Query(Boolean),
-      p_int: Query(Int),
-      p_num: Query(Num),
-      p_str: Query(Str),
-      p_bool: Query(Bool),
+      p_number: Query(Number, {
+        required: false,
+      }),
+      p_string: Query(String, {
+        required: false,
+      }),
+      p_boolean: Query(Boolean, {
+        required: false,
+      }),
+      p_int: Query(Int, {
+        required: false,
+      }),
+      p_num: Query(Num, {
+        required: false,
+      }),
+      p_str: Query(Str, {
+        required: false,
+      }),
+      p_bool: Query(Bool, {
+        required: false,
+      }),
       p_enumeration: Query(Enumeration, {
         values: {
           json: 'ENUM_JSON',
           csv: 'ENUM_CSV',
         },
+        required: true,
       }),
       p_enumeration_insensitive: Query(Enumeration, {
         values: {
@@ -42,18 +57,34 @@ export class ToDoList extends OpenAPIRoute {
           csv: 'csv',
         },
         enumCaseSensitive: false,
+        required: true,
       }),
-      p_datetime: Query(DateTime),
-      p_dateonly: Query(DateOnly),
+      p_datetime: Query(DateTime, {
+        required: false,
+      }),
+      p_dateonly: Query(DateOnly, {
+        required: false,
+      }),
       p_regex: Query(Regex, {
         pattern:
           '^[\\+]?[(]?[0-9]{3}[)]?[-\\s\\.]?[0-9]{3}[-\\s\\.]?[0-9]{4,6}$',
+        required: false,
       }),
-      p_email: Query(Email),
-      p_uuid: Query(Uuid),
-      p_hostname: Query(Hostname),
-      p_ipv4: Query(Ipv4),
-      p_ipv6: Query(Ipv6),
+      p_email: Query(Email, {
+        required: false,
+      }),
+      p_uuid: Query(Uuid, {
+        required: false,
+      }),
+      p_hostname: Query(Hostname, {
+        required: false,
+      }),
+      p_ipv4: Query(Ipv4, {
+        required: false,
+      }),
+      p_ipv6: Query(Ipv6, {
+        required: false,
+      }),
       p_optional: Query(Int, {
         required: false,
       }),


### PR DESCRIPTION
I spotted an inconsistency in how we decode query parameters, especially around the `+` character. Here's a quick breakdown:

In Python:
```python
from urllib.parse import urlencode
print(urlencode({'p_string': '+ +'}))  # Outputs: 'p_string=%2B+%2B'
```

In JS:
```javascript
console.log(decodeURIComponent('%2B+%2B'))  // Outputs: '+++'
```

**Versions:**
- Python: 3.11.4
- Node: v18.15.0

**What I did:**
- Used the `URL` object's `searchParams` for the extraction of query parameters.

The solution is from: [Cloudflare community post](https://community.cloudflare.com/t/parse-url-query-strings-with-cloudflare-workers/90286/3).
