### PR TITLE
Fix sending empty query parameters being parsed as empty strings instead of null

### DIFF
--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -305,7 +305,13 @@ export function extractQueryParameters(
   }
 
   const params: Record<string, any> = {}
-  for (const [key, value] of searchParams.entries()) {
+  for (let [key, value] of searchParams.entries()) {
+    // Query parameters can be empty strings, that should equal to null as nothing was provided
+    if (value === '') {
+      // @ts-ignore
+      value = null
+    }
+
     if (params[key] === undefined) {
       params[key] = value
     } else if (!Array.isArray(params[key])) {

--- a/tests/integration/parameters.test.ts
+++ b/tests/integration/parameters.test.ts
@@ -63,6 +63,18 @@ describe('queryParametersValidation', () => {
     expect(findError(resp.errors, 'p_string')).toBeUndefined()
   })
 
+  test('checkStringInvalidEmpty', async () => {
+    const qs = '?p_string='
+    const request = await todoRouter.handle(
+      buildRequest({ method: 'GET', path: `/todos${qs}` })
+    )
+    const resp = await request.json()
+
+    expect(findError(resp.errors, 'p_string')).toEqual(
+      'Expected string, received null'
+    )
+  })
+
   test('checkBooleanInvalid', async () => {
     const qs = '?p_boolean=asd'
     const request = await todoRouter.handle(


### PR DESCRIPTION
Previous to this pr, if you defined as query parameter as string and required like this:
```ts
export class ToDoList extends OpenAPIRoute {
  static schema = {
    parameters: {
      my_field: Query(String),
    }
  }
} 
```

And sent a request with this query string `?my_field=` it would pass the required validation as it was parsed as an empty string, but now it will trigger the right error saying `Expected string, received null`