### PR TITLE
Refactor js-yaml import usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@rollup/plugin-terser": "^0.2.1",
         "@rollup/plugin-typescript": "^10.0.1",
         "@types/jest": "^29.0.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.3.1",
         "@types/service-worker-mock": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.60.0",
@@ -1860,6 +1861,12 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.12",
@@ -8991,6 +8998,12 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.12",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@rollup/plugin-terser": "^0.2.1",
     "@rollup/plugin-typescript": "^10.0.1",
     "@types/jest": "^29.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.3.1",
     "@types/service-worker-mock": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.60.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -26,5 +26,5 @@ export default defineConfig({
       ],
     }),
   ],
-  external: ['itty-router', 'zod', '@asteasolutions/zod-to-openapi'],
+  external: ['itty-router', 'zod', '@asteasolutions/zod-to-openapi', 'js-yaml'],
 })

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -16,7 +16,7 @@ import { OpenAPIRegistryMerger } from './zod/registry'
 import { z } from 'zod'
 import { OpenAPIObject } from 'openapi3-ts/oas31'
 import { OpenAPIRoute } from './route'
-const yaml = require('js-yaml')
+import yaml from 'js-yaml'
 
 export type Route = <
   RequestType = IRequest,


### PR DESCRIPTION
Hi! I've open this simple PR to adjust the import usage of js-yaml that provides the yaml schema. It consist of three changes:
1) In order to maintain project consistency, use import instead of require. It also prevents this issue when the code is loaded as ESM. 
![image](https://github.com/cloudflare/itty-router-openapi/assets/6892708/f38df22b-0bd5-44f7-ae94-064dcef23c72)

2) Add the types for js-yaml as dev dependency.

3) Since  js-yaml is now imported, it needs to be marked as external dependency for rollup to avoid this warning:
![image](https://github.com/cloudflare/itty-router-openapi/assets/6892708/c650cc52-1cf8-457e-9257-f21204715c3e)
